### PR TITLE
feat: vendorId in purchase

### DIFF
--- a/packages/destination-actions/src/destinations/topsort/purchase/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/topsort/purchase/__tests__/__snapshots__/index.test.ts.snap
@@ -1,6 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Topsort.purchase should be successful with default mappings and products object, including vendorId 1`] = `
+exports[`Topsort.purchase should be successful with default mappings and products object 1`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer bar",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Topsort.purchase should be successful with default mappings and products object, including brand as vendorId 1`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer bar",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Topsort.purchase should be successful with default mappings and products object, including custom vendorId 1`] = `
 Headers {
   Symbol(map): Object {
     "authorization": Array [

--- a/packages/destination-actions/src/destinations/topsort/purchase/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/topsort/purchase/__tests__/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Topsort.purchase should be successful with default mappings and products object 1`] = `
+exports[`Topsort.purchase should be successful with default mappings and products object, including vendorId 1`] = `
 Headers {
   Symbol(map): Object {
     "authorization": Array [

--- a/packages/destination-actions/src/destinations/topsort/purchase/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/topsort/purchase/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -10,6 +10,7 @@ Object {
           "productId": "4mevd8V",
           "quantity": -6621698275147776,
           "unitPrice": -66216982751477.76,
+          "vendorId": "4mevd8V",
         },
       ],
       "occurredAt": "2021-02-01T00:00:00.000Z",

--- a/packages/destination-actions/src/destinations/topsort/purchase/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/topsort/purchase/__tests__/index.test.ts
@@ -6,7 +6,49 @@ import Destination from '../../index'
 const testDestination = createTestIntegration(Destination)
 
 describe('Topsort.purchase', () => {
-  it('should be successful with default mappings and products object, including vendorId', async () => {
+  it('should be successful with default mappings and products object', async () => {
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      products: [
+        {
+          product_id: '123',
+          price: 100,
+          quantity: 1
+        }
+      ]
+    })
+
+    const responses = await testDestination.testAction('purchase', {
+      event,
+      settings: {
+        api_key: 'bar'
+      },
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.headers).toMatchSnapshot()
+    expect(responses[0].options.json).toMatchObject({
+      purchases: expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.any(String),
+          occurredAt: expect.any(String),
+          opaqueUserId: expect.any(String),
+          items: [
+            {
+              productId: '123',
+              unitPrice: 100,
+              quantity: 1
+            }
+          ]
+        })
+      ])
+    })
+  })
+
+  it('should be successful with default mappings and products object, including brand as vendorId', async () => {
     nock(/.*/).persist().post(/.*/).reply(200)
 
     const event = createTestEvent({
@@ -16,6 +58,50 @@ describe('Topsort.purchase', () => {
           price: 100,
           quantity: 1,
           brand: 'v123'
+        }
+      ]
+    })
+
+    const responses = await testDestination.testAction('purchase', {
+      event,
+      settings: {
+        api_key: 'bar'
+      },
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.headers).toMatchSnapshot()
+    expect(responses[0].options.json).toMatchObject({
+      purchases: expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.any(String),
+          occurredAt: expect.any(String),
+          opaqueUserId: expect.any(String),
+          items: [
+            {
+              productId: '123',
+              unitPrice: 100,
+              quantity: 1,
+              vendorId: 'v123'
+            }
+          ]
+        })
+      ])
+    })
+  })
+
+  it('should be successful with default mappings and products object, including custom vendorId', async () => {
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      products: [
+        {
+          product_id: '123',
+          price: 100,
+          quantity: 1,
+          vendorId: 'v123'
         }
       ]
     })

--- a/packages/destination-actions/src/destinations/topsort/purchase/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/topsort/purchase/__tests__/index.test.ts
@@ -10,16 +10,14 @@ describe('Topsort.purchase', () => {
     nock(/.*/).persist().post(/.*/).reply(200)
 
     const event = createTestEvent({
-      properties: {
-        products: [
-          {
-            product_id: '123',
-            price: 100,
-            quantity: 1,
-            vendor_id: 'v123'
-          }
-        ]
-      }
+      products: [
+        {
+          product_id: '123',
+          price: 100,
+          quantity: 1,
+          brand: 'v123'
+        }
+      ]
     })
 
     const responses = await testDestination.testAction('purchase', {

--- a/packages/destination-actions/src/destinations/topsort/purchase/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/topsort/purchase/__tests__/index.test.ts
@@ -6,7 +6,7 @@ import Destination from '../../index'
 const testDestination = createTestIntegration(Destination)
 
 describe('Topsort.purchase', () => {
-  it('should be successful with default mappings and products object', async () => {
+  it('should be successful with default mappings and products object, including vendorId', async () => {
     nock(/.*/).persist().post(/.*/).reply(200)
 
     const event = createTestEvent({
@@ -15,7 +15,8 @@ describe('Topsort.purchase', () => {
           {
             product_id: '123',
             price: 100,
-            quantity: 1
+            quantity: 1,
+            vendor_id: 'v123'
           }
         ]
       }
@@ -42,7 +43,8 @@ describe('Topsort.purchase', () => {
             {
               productId: '123',
               unitPrice: 100,
-              quantity: 1
+              quantity: 1,
+              vendorId: 'v123'
             }
           ]
         })

--- a/packages/destination-actions/src/destinations/topsort/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/topsort/purchase/generated-types.ts
@@ -29,5 +29,9 @@ export interface Payload {
      * Count of products purchased.
      */
     quantity?: number
+    /**
+     * The vendor ID of the product being purchased.
+     */
+    vendorId?: string
   }[]
 }

--- a/packages/destination-actions/src/destinations/topsort/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/topsort/purchase/index.ts
@@ -61,11 +61,17 @@ const action: ActionDefinition<Settings, Payload> = {
           description: 'Count of products purchased.',
           type: 'integer',
           required: false
+        },
+        vendorId: {
+          label: 'Vendor ID',
+          description: 'The vendor ID of the product being purchased.',
+          type: 'string',
+          required: false
         }
       },
       default: {
         '@arrayPath': [
-          '$.properties.products',
+          '$.products',
           {
             productId: { '@path': '$.product_id' },
             unitPrice: { '@path': '$.price' },

--- a/packages/destination-actions/src/destinations/topsort/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/topsort/purchase/index.ts
@@ -76,7 +76,13 @@ const action: ActionDefinition<Settings, Payload> = {
             productId: { '@path': '$.product_id' },
             unitPrice: { '@path': '$.price' },
             quantity: { '@path': '$.quantity' },
-            vendorId: { '@path': '$.brand' }
+            vendorId: {
+              '@if': {
+                exists: { '@path': '$.vendorId' },
+                then: { '@path': '$.vendorId' },
+                else: { '@path': '$.brand' }
+              }
+            }
           }
         ]
       }

--- a/packages/destination-actions/src/destinations/topsort/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/topsort/purchase/index.ts
@@ -69,7 +69,8 @@ const action: ActionDefinition<Settings, Payload> = {
           {
             productId: { '@path': '$.product_id' },
             unitPrice: { '@path': '$.price' },
-            quantity: { '@path': '$.quantity' }
+            quantity: { '@path': '$.quantity' },
+            vendorId: { '@path': '$.brand' }
           }
         ]
       }


### PR DESCRIPTION
To be able to send vendorId in Order Completed events.

To Do

- [x] Fix default mapping schema from Order Completed (wasn't correctly mapping products object as stated in [Order Completed Specs](https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed))
- [x] Added optional vendorId to purchase products mapping
- [x] Added conditional mapping for custom vendorId field or default brand field
- [x] Added tests for optional and conditional default vendorId field